### PR TITLE
Add basic Electron bubble contact app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-"# bubble-contact-web" 
+# Bubble Contact Web
+
+This repository contains a minimal Electron application for experimenting with a bubble-based contact interface. It is a starting point based on the full specification provided.
+
+## Development
+
+1. Install dependencies (requires internet):
+   ```bash
+   npm install
+   ```
+2. Start the app:
+   ```bash
+   npm start
+   ```
+
+Contacts are stored locally in `contacts.json`.

--- a/contacts.json
+++ b/contacts.json
@@ -1,0 +1,4 @@
+[
+  {"id":"1","firstName":"Alice","lastName":"Smith","email":"alice@example.com"},
+  {"id":"2","firstName":"Bob","lastName":"Jones","email":"bob@example.com"}
+]

--- a/main.js
+++ b/main.js
@@ -1,0 +1,28 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1000,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: false,
+      nodeIntegration: true,
+    },
+  });
+
+  win.loadFile(path.join(__dirname, 'src/index.html'));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bubble-contact-web",
+  "version": "1.0.0",
+  "description": "\"# bubble-contact-web\"",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "d3": "^7.8.5",
+    "electron": "^28.2.4"
+  }
+}

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,3 @@
+window.addEventListener('DOMContentLoaded', () => {
+  // Placeholder for future context bridging
+});

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bubble Contacts</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="toolbar">
+    <input id="search" placeholder="Search contacts" />
+    <button id="add-btn">Add Contact</button>
+  </div>
+  <div id="bubble-container"></div>
+  <div id="side-panel" class="hidden">
+    <button id="close-panel">X</button>
+    <div id="detail-content"></div>
+  </div>
+
+  <script src="../node_modules/d3/dist/d3.min.js"></script>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const path = require('path');
+const { ipcRenderer } = require('electron');
+
+const dataPath = path.join(__dirname, '..', 'contacts.json');
+let contacts = [];
+
+function loadContacts() {
+  try {
+    const raw = fs.readFileSync(dataPath, 'utf-8');
+    contacts = JSON.parse(raw);
+  } catch (e) {
+    contacts = [];
+  }
+}
+
+function saveContacts() {
+  fs.writeFileSync(dataPath, JSON.stringify(contacts, null, 2));
+}
+
+function createSVG() {
+  const svg = d3.select('#bubble-container').append('svg')
+    .attr('width', window.innerWidth)
+    .attr('height', window.innerHeight);
+
+  return svg;
+}
+
+let svg = createSVG();
+let simulation;
+
+function render() {
+  svg.selectAll('*').remove();
+
+  const nodes = contacts.map(c => Object.assign({}, c));
+  const g = svg.selectAll('g').data(nodes, d => d.id).join('g');
+
+  g.append('circle')
+    .attr('r', 40)
+    .attr('class', 'circle');
+
+  g.append('text')
+    .attr('text-anchor', 'middle')
+    .attr('dy', '.35em')
+    .text(d => d.firstName);
+
+  g.on('click', (_, d) => openDetail(d));
+
+  simulation = d3.forceSimulation(nodes)
+    .force('charge', d3.forceManyBody().strength(-50))
+    .force('center', d3.forceCenter(window.innerWidth/2, window.innerHeight/2))
+    .force('collision', d3.forceCollide(45))
+    .on('tick', () => {
+      g.attr('transform', d => `translate(${d.x},${d.y})`);
+    });
+}
+
+function openDetail(contact) {
+  const panel = document.getElementById('side-panel');
+  const content = document.getElementById('detail-content');
+  content.innerHTML = '';
+  for (const key of ['firstName','lastName','email']) {
+    const div = document.createElement('div');
+    const label = document.createElement('label');
+    label.textContent = key;
+    const input = document.createElement('input');
+    input.value = contact[key] || '';
+    input.addEventListener('change', () => {
+      contact[key] = input.value;
+      saveContacts();
+      render();
+    });
+    div.appendChild(label);
+    div.appendChild(input);
+    content.appendChild(div);
+  }
+  panel.classList.add('show');
+}
+
+document.getElementById('close-panel').addEventListener('click', () => {
+  document.getElementById('side-panel').classList.remove('show');
+});
+
+document.getElementById('add-btn').addEventListener('click', () => {
+  const newContact = { id: Date.now().toString(), firstName: 'New', lastName: 'Contact' };
+  contacts.push(newContact);
+  saveContacts();
+  render();
+  openDetail(newContact);
+});
+
+window.addEventListener('resize', () => {
+  svg.attr('width', window.innerWidth).attr('height', window.innerHeight);
+  simulation.force('center', d3.forceCenter(window.innerWidth/2, window.innerHeight/2));
+});
+
+loadContacts();
+render();

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,40 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  overflow: hidden;
+  background: #111;
+  color: #fff;
+}
+#toolbar {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 10;
+}
+#bubble-container {
+  position: absolute;
+  top: 0; bottom: 0; left: 0; right: 0;
+}
+#side-panel {
+  position: absolute;
+  right: 0;
+  top: 0; bottom: 0;
+  width: 300px;
+  background: #222;
+  padding: 10px;
+  overflow-y: auto;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+}
+#side-panel.show {
+  transform: translateX(0);
+}
+.hidden {
+  display: none;
+}
+.circle {
+  cursor: pointer;
+  stroke: #fff;
+  stroke-width: 2;
+  fill: rgba(100,150,250,0.7);
+}


### PR DESCRIPTION
## Summary
- initialize package.json with Electron and D3 deps
- add main process and preload scripts
- create renderer with simple bubble visualization and side panel
- provide sample contacts and basic styling
- document setup instructions

## Testing
- `npm test` *(fails: no test specified)*
- `npm install electron@latest d3@latest --save` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_688150f5d3448320b6e2ef4d51375246