### PR TITLE
Improve tag UI and add zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,14 @@
         transform:translateX(100%);
         overflow-y:auto;
       }
+      #sidepanel form {
+        display:flex;
+        flex-direction:column;
+        height:100%;
+      }
+      #sidepanel form button[type=submit] {
+        margin-top:auto;
+      }
       #sidepanel.open { transform:translateX(0); }
       #close {
         background:none;
@@ -82,6 +90,10 @@
       }
       .form-group { margin-bottom:10px; }
       label { display:block; margin-bottom:4px; }
+      input[type=text] {
+        width:100%;
+        box-sizing:border-box;
+      }
       .add-bubble {
         position:fixed;
         bottom:20px;
@@ -97,6 +109,18 @@
         justify-content:center;
         cursor:pointer;
       }
+      #zoom-control {
+        position:fixed;
+        bottom:30px;
+        right:80px;
+        display:flex;
+        align-items:center;
+        background:rgba(0,0,0,0.5);
+        padding:4px 8px;
+        border-radius:8px;
+        color:#fff;
+      }
+      #zoom-control input[type=range] { width:120px; }
       #tagPanel {
         position:fixed;
         top:40px;
@@ -127,6 +151,7 @@
       }
       .tag-box.selected { background-color:gold; color:black; }
       .tag-area { display:flex; flex-wrap:wrap; }
+      #tagList { display:flex; flex-wrap:wrap; }
     </style>
 </head>
 <body>
@@ -155,9 +180,15 @@
         <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="rgba(0,0,0,0.3)" />
       </filter>
     </defs>
-    <g id="circleGroup"></g>
-    <g id="linkGroup"></g>
+    <g id="viewGroup">
+      <g id="linkGroup"></g>
+      <g id="circleGroup"></g>
+    </g>
   </svg>
+  <div id="zoom-control">
+    <input id="zoom-slider" type="range" min="50" max="200" value="100" />
+    <span id="zoom-display">100%</span>
+  </div>
   <div class="add-bubble" id="add-bubble">+</div>
   <div id="sidepanel">
     <button id="close">&times;</button>

--- a/index.js
+++ b/index.js
@@ -34,6 +34,15 @@ function createWindow () {
     }
   });
   win.loadFile('index.html');
+
+  // Inform renderer when the window is resized or moved so the layout can
+  // recenter the bubbles. This helps keep bubbles visible when the window is
+  // snapped or dragged between displays.
+  const sendResize = () => {
+    if (win.webContents) win.webContents.send('window-resized');
+  };
+  win.on('resize', sendResize);
+  win.on('move', sendResize);
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- add resize/move listener so bubbles stay on screen
- show tag usage counts and sort by most used
- stack tags neatly in panel and keep save button visible
- support multiple tags on creation and auto-tag company
- add zoom control with slider and mouse wheel
- adjust bubble zones responsively

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882866ba6c4832089b5b474592183f9