### PR TITLE
Improve visibility of bubble labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,10 @@
         fill: #fff;
         font-weight: normal; /* remove bold for a lighter look */
         text-shadow: 0 2px 4px rgba(0,0,0,0.6); /* subtle drop shadow */
+        stroke: #000;
+        stroke-width: 2px;
+        paint-order: stroke fill;
+        stroke-linejoin: round;
       }
       #bubbleCanvas g.contact .bubble-circle {
         animation: bubbleShimmer 6s ease-in-out infinite;

--- a/renderer.js
+++ b/renderer.js
@@ -253,10 +253,12 @@ function render() {
     .remove();
 
   contactGroup.selectAll('g.contact')
-    .style('display',d=> matchesSearch(d)? null : 'none')
-    .style('opacity', d=>{
-      if(selectedFilterTags.length===0) return 1;
-      return d.matchLevel===2?1:d.matchLevel===1?0.6:0.1;
+    .style('display', d => matchesSearch(d) ? null : 'none');
+
+  contactGroup.selectAll('g.contact').selectAll('circle')
+    .style('opacity', d => {
+      if(selectedFilterTags.length === 0) return 1;
+      return d.matchLevel === 2 ? 1 : d.matchLevel === 1 ? 0.6 : 0.1;
     });
 
   // FULL simulation reset to eliminate ghost particles


### PR DESCRIPTION
## Summary
- outline bubble label text for better visibility
- keep bubble names fully opaque when fading circles due to filtering

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883b1987b588320a6eccb8aec40b3c9