### PR TITLE
Grey out impossible tag selections

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,6 +197,10 @@
         cursor:pointer;
       }
       .tag-box.selected { background-color:gold; color:black; }
+      .tag-box.disabled {
+        background-color:#777;
+        color:#ccc;
+      }
       .tag-area { display:flex; flex-wrap:wrap; }
       #tagList { display:flex; flex-wrap:wrap; }
       #active-tags { width:260px; }

--- a/renderer.js
+++ b/renderer.js
@@ -358,6 +358,11 @@ function updateAllTags(){
   });
 }
 
+function countContactsForTags(tags){
+  const unique = Array.from(new Set(tags));
+  return contacts.filter(c=>unique.every(t=>c.tags.includes(t))).length;
+}
+
 function renderTagPanel(){
   updateAllTags();
   const tags = Array.from(allTags);
@@ -370,6 +375,11 @@ function renderTagPanel(){
   const enter = panel.enter().append('div').attr('class','tag-box');
   enter.merge(panel)
     .classed('selected', d=>selectedFilterTags.includes(d))
+    .classed('disabled', d=>{
+      const tagList = selectedFilterTags.slice();
+      if(!tagList.includes(d)) tagList.push(d);
+      return countContactsForTags(tagList) === 0;
+    })
     .text(d=>`${d} (${tagCounts.get(d)||0})`)
     .on('click',(event,d)=>toggleFilterTag(d));
   panel.exit().remove();


### PR DESCRIPTION
## Summary
- highlight tags in the filter panel that cannot match contacts
- add styling for disabled tags

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883b44cbebc8320a7f532c50a94356c