### PR TITLE
Add autocomplete for tags and company

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,37 @@
       body.dark #contacts-list div:hover {
         background:#555;
       }
+      .suggest-container { position:relative; }
+      #tag-suggestions,#company-suggestions {
+        position:absolute;
+        top:100%;
+        left:0;
+        right:0;
+        background:#fff;
+        color:#000;
+        border:1px solid #ccc;
+        max-height:200px;
+        overflow-y:auto;
+        display:none;
+        z-index:1000;
+      }
+      body.dark #tag-suggestions,
+      body.dark #company-suggestions {
+        background:#444;
+        color:#fff;
+        border-color:#666;
+      }
+      #tag-suggestions div,#company-suggestions div {
+        padding:4px 8px;
+        cursor:pointer;
+      }
+      #tag-suggestions div:hover,#company-suggestions div:hover {
+        background:#ddd;
+      }
+      body.dark #tag-suggestions div:hover,
+      body.dark #company-suggestions div:hover {
+        background:#555;
+      }
       #viz,#bubbleCanvas {
         width:calc(100% - 225px);
         min-height:calc(100vh - 40px); /* still fill initial view */
@@ -325,11 +356,17 @@
       </div>
       <div class="form-group">
         <label>Company:</label>
-        <input id="company" type="text" />
+        <div class="suggest-container">
+          <input id="company" type="text" />
+          <div id="company-suggestions"></div>
+        </div>
       </div>
       <div class="form-group">
         <label>Tags:</label>
-        <input id="newTag" type="text" placeholder="Add tag" />
+        <div class="suggest-container">
+          <input id="newTag" type="text" placeholder="Add tag" />
+          <div id="tag-suggestions"></div>
+        </div>
       </div>
       <div class="form-group">
         <label>Active Tags:</label>

--- a/renderer.js
+++ b/renderer.js
@@ -4,6 +4,7 @@ let simulation;
 let searchTerm = '';
 let allTags = new Set();
 let tagCounts = new Map();
+let allCompanies = new Set();
 let selectedFilterTags = [];
 let formSelectedTags = [];
 let focusedContact = null;
@@ -358,7 +359,9 @@ function setupSim(){
 function updateAllTags(){
   allTags = new Set();
   tagCounts = new Map();
+  allCompanies = new Set();
   contacts.forEach(c=>{
+    if(c.company) allCompanies.add(c.company);
     c.tags.forEach(t=>{
       allTags.add(t);
       tagCounts.set(t, (tagCounts.get(t)||0)+1);
@@ -679,6 +682,12 @@ const zoomResetBtn = document.getElementById('zoom-reset');
 const contactsToggle = document.getElementById('contacts-toggle');
 const contactsList = document.getElementById('contacts-list');
 const contactCountSpan = document.getElementById('contact-count');
+const tagInput = document.getElementById('newTag');
+const tagSuggestions = document.getElementById('tag-suggestions');
+let tagHovered = false;
+const companyInput = document.getElementById('company');
+const companySuggestions = document.getElementById('company-suggestions');
+let companyHovered = false;
 
 function applyZoom(level){
   zoomLevel = Math.min(2, Math.max(0.5, level));
@@ -786,6 +795,57 @@ function buildContactsList(){
   });
 }
 
+function updateTagSuggestions(){
+  if(!tagSuggestions) return;
+  tagSuggestions.innerHTML = '';
+  const term = tagInput.value.trim().toLowerCase();
+  if(!term){
+    tagSuggestions.style.display = 'none';
+    return;
+  }
+  const matches = Array.from(allTags)
+    .filter(t => t.toLowerCase().includes(term) && !formSelectedTags.includes(t))
+    .slice(0,5);
+  matches.forEach(t => {
+    const div = document.createElement('div');
+    div.textContent = t;
+    div.addEventListener('mousedown', e => {
+      e.preventDefault();
+      if(!formSelectedTags.includes(t)) formSelectedTags.push(t);
+      renderTagOptions();
+      renderTagPanel();
+      tagInput.value = '';
+      tagSuggestions.style.display = 'none';
+    });
+    tagSuggestions.appendChild(div);
+  });
+  tagSuggestions.style.display = matches.length ? 'block' : 'none';
+}
+
+function updateCompanySuggestions(){
+  if(!companySuggestions) return;
+  companySuggestions.innerHTML = '';
+  const term = companyInput.value.trim().toLowerCase();
+  if(!term){
+    companySuggestions.style.display = 'none';
+    return;
+  }
+  const matches = Array.from(allCompanies)
+    .filter(c => c.toLowerCase().includes(term))
+    .slice(0,5);
+  matches.forEach(name => {
+    const div = document.createElement('div');
+    div.textContent = name;
+    div.addEventListener('mousedown', e => {
+      e.preventDefault();
+      companyInput.value = name;
+      companySuggestions.style.display = 'none';
+    });
+    companySuggestions.appendChild(div);
+  });
+  companySuggestions.style.display = matches.length ? 'block' : 'none';
+}
+
 searchInput.addEventListener('input', e=>{
   searchTerm = e.target.value;
   render();
@@ -798,6 +858,20 @@ searchInput.addEventListener('blur', ()=>{
 
 searchResults.addEventListener('mouseenter',()=>{ resultsHovered = true; });
 searchResults.addEventListener('mouseleave',()=>{ resultsHovered = false; clearSearch(); render(); });
+
+tagInput.addEventListener('input', updateTagSuggestions);
+tagInput.addEventListener('blur', () => {
+  setTimeout(() => { if(!tagHovered){ tagSuggestions.style.display = 'none'; } }, 100);
+});
+tagSuggestions.addEventListener('mouseenter', () => { tagHovered = true; });
+tagSuggestions.addEventListener('mouseleave', () => { tagHovered = false; tagSuggestions.style.display = 'none'; });
+
+companyInput.addEventListener('input', updateCompanySuggestions);
+companyInput.addEventListener('blur', () => {
+  setTimeout(() => { if(!companyHovered){ companySuggestions.style.display = 'none'; } }, 100);
+});
+companySuggestions.addEventListener('mouseenter', () => { companyHovered = true; });
+companySuggestions.addEventListener('mouseleave', () => { companyHovered = false; companySuggestions.style.display = 'none'; });
 
 if(contactsToggle){
   contactsToggle.addEventListener('click',()=>{


### PR DESCRIPTION
## Summary
- add dropdown suggestion lists for company and tags
- track all company names alongside tags
- handle suggestion interactions in renderer

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883b90fdd1883209fdae6f3b1831c95