### PR TITLE
Add ability to remove tags globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,11 +226,17 @@
         margin:4px;
         font-size:0.85em;
         cursor:pointer;
+        position:relative;
       }
       .tag-box.selected { background-color:gold; color:black; }
       .tag-box.disabled {
         background-color:#777;
         color:#ccc;
+      }
+      .tag-box .delete-tag {
+        margin-left:6px;
+        color:#ff6666;
+        cursor:pointer;
       }
       .tag-area { display:flex; flex-wrap:wrap; }
       #tagList { display:flex; flex-wrap:wrap; }


### PR DESCRIPTION
## Summary
- allow removing a tag from all contacts
- show delete icon for each tag in the tag pane

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883ba3eab248320b51c87082d0eb1ca