### PR TITLE
Highlight contacts on click

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,6 +308,10 @@
         <stop offset="0%" stop-color="rgba(255,255,255,0.9)" />
         <stop offset="100%" stop-color="gold" />
       </radialGradient>
+      <radialGradient id="marbleGrey" cx="35%" cy="35%" r="65%">
+        <stop offset="0%" stop-color="rgba(255,255,255,0.9)" />
+        <stop offset="100%" stop-color="#555" />
+      </radialGradient>
       <filter id="marbleShadow" x="-20%" y="-20%" width="140%" height="140%">
         <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="rgba(0,0,0,0.3)" />
       </filter>

--- a/renderer.js
+++ b/renderer.js
@@ -240,6 +240,7 @@ function render() {
   merged.select('circle.bubble-circle')
     .attr('fill', d => {
       if(selectedFilterTags.length && d.matchLevel === 2) return 'url(#marbleGold)';
+      if(selectedFilterTags.length && d.matchLevel === 0) return 'url(#marbleGrey)';
       return `url(#${d.gradientId})`;
     });
 
@@ -267,7 +268,7 @@ function render() {
   contactGroup.selectAll('g.contact').selectAll('circle')
     .style('opacity', d => {
       if(selectedFilterTags.length === 0) return 1;
-      return d.matchLevel === 2 ? 1 : d.matchLevel === 1 ? 0.6 : 0.1;
+      return d.matchLevel === 2 ? 1 : d.matchLevel === 1 ? 0.6 : 0.2;
     });
 
   // FULL simulation reset to eliminate ghost particles


### PR DESCRIPTION
## Summary
- add grey marble gradient
- color unrelated contacts grey when filtering
- tweak faded opacity for unrelated contacts

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails: electron not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883bbebdc9c832097a1960555d655ea