### PR TITLE
Fix tag-heavy contact form scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
       #sidepanel form {
         display:flex;
         flex-direction:column;
-        height:100%;
+        min-height:100%;
       }
       /* Position submit button below tags instead of pinned to bottom */
       #sidepanel form button[type=submit] {


### PR DESCRIPTION
## Summary
- allow sidepanel form to grow beyond panel height so overflow works

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883bdc0aefc832090bf632b83d347a4